### PR TITLE
move rnpm config to react-native.config.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,11 +56,6 @@
   "jest": {
     "preset": "react-native"
   },
-  "rnpm": {
-    "assets": [
-      "./node_modules/@anarock/pebble/native/icons/"
-    ]
-  },
   "husky": {
     "hooks": {
       "pre-commit": "pretty-quick --staged"

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     }
   },
   "peerDependencies": {
-    "@anarock/pebble": "^0.46.1"
+    "@anarock/pebble": "^0.46.1",
+    "react-native": "^0.60.0"
   }
 }

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  assets: ["./node_modules/@anarock/pebble/native/icons/"]
+};


### PR DESCRIPTION
migration guide for libraries on [react-native-community/cli](https://github.com/react-native-community/cli/blob/master/docs/configuration.md#libraries)

_**Note:** breaking change for projects using RN<0.60.0_