### PR TITLE
Make closeModal public

### DIFF
--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -31,7 +31,7 @@ export default class extends React.PureComponent<SearchInputProps> {
     showModal: false
   };
 
-  private closeModal = () => {
+  public closeModal = () => {
     this.setState({
       showModal: false
     });


### PR DESCRIPTION
This function was being used (via ref) even though private.
Can't think of a way to control using props.

Please review: @zhirzh @pranjal-jain 